### PR TITLE
add missing header include for std::accumulate

### DIFF
--- a/lib/libclang-vim/tokenizer.cpp
+++ b/lib/libclang-vim/tokenizer.cpp
@@ -1,4 +1,5 @@
 #include "tokenizer.hpp"
+#include <numeric>
 
 CXSourceRange libclang_vim::tokenizer::get_range_whole_file(
     const location_tuple& tuple,


### PR DESCRIPTION
This fixes the compilation error: no member named 'accumulate' in namespace 'std'.